### PR TITLE
[MRG + 1] expose 2 unifization options

### DIFF
--- a/sammba/externals/nipype/interfaces/afni/utils.py
+++ b/sammba/externals/nipype/interfaces/afni/utils.py
@@ -2291,6 +2291,7 @@ class UnifizeInputSpec(AFNICommandInputSpec):
         exists=True,
         copyfile=False)
     out_file = File(
+        name_template='%s_unifized',
         desc='output image file name',
         argstr='-prefix %s',
         name_source='in_file')
@@ -2337,6 +2338,22 @@ class UnifizeInputSpec(AFNICommandInputSpec):
              'b = bottom percentile of normalizing data range, [default=70.0]\n'
              'r = top percentile of normalizing data range, [default=80.0]\n',
         argstr='-rbt %f %f %f')
+    t2_up = traits.Float(
+        desc='Option for AFNI experts only.'
+             'Set the upper percentile point used for T2-T1 inversion. '
+             'Allowed to be anything between 90 and 100 (inclusive), with '
+             'default to 98.5  (for no good reason).',
+        argstr='-T2up %f')
+    cl_frac = traits.Float(
+        desc='Option for AFNI experts only.'
+             'Set the automask \'clip level fraction\'. Must be between '
+             '0.1 and 0.9. A small fraction means to make the initial '
+             'threshold for clipping (a la 3dClipLevel) smaller, which '
+             'will tend to make the mask larger.  [default=0.1]',
+        argstr='-clfrac %f')
+    quiet = traits.Bool(
+        desc='Don\'t print the progress messages.',
+        argstr='-quiet')
 
 
 class UnifizeOutputSpec(TraitedSpec):

--- a/sammba/registration/struct.py
+++ b/sammba/registration/struct.py
@@ -51,12 +51,12 @@ def anats_to_common(anat_filenames, write_dir, brain_volume,
         verbosity in any case.
 
     unifize_kwargs : dict, optional
-        Is passed to sammba.externals.nipype.interfaces.afni.Unifize, to tune
-        bias correction done prior to registration.
+        Is passed to sammba.externals.nipype.interfaces.afni.Unifize, to
+        control bias correction of the template.
 
     brain_extraction_unifize_kwargs : dict, optional
         Is passed to sammba.externals.nipype.interfaces.afni.Unifize, to tune
-        bias correction done prior to brain extraction step.
+        the seperate bias correction step done prior to brain extraction.
 
     Returns
     -------
@@ -145,7 +145,7 @@ def anats_to_common(anat_filenames, write_dir, brain_volume,
     #
     # First we loop through anatomical scans and correct intensities for bias.
     if brain_extraction_unifize_kwargs is None:
-        brain_extraction_unifize_kwargs = {'clfrac': .2}
+        brain_extraction_unifize_kwargs = {'cl_frac': .2}
 
     brain_extraction_in_files = []
     for n, anat_file in enumerate(copied_anat_filenames):
@@ -168,7 +168,7 @@ def anats_to_common(anat_filenames, write_dir, brain_volume,
     # and set the NIfTI image centre (as defined in the header) to the CoM
     # of the extracted brain.
     if unifize_kwargs is None:
-        unifize_kwargs = {'clfrac': .2}
+        unifize_kwargs = {'cl_frac': .2}
 
     unifized_files = []
     for n, anat_file in enumerate(copied_anat_filenames):

--- a/sammba/registration/struct.py
+++ b/sammba/registration/struct.py
@@ -144,7 +144,7 @@ def anats_to_common(anat_filenames, write_dir, brain_volume,
     #
     # First we loop through anatomical scans and correct intensities for bias.
     if brain_extraction_unifize_kwargs is None:
-        brain_extraction_unifize_kwargs = {'cl_frac': .2}
+        brain_extraction_unifize_kwargs = {}
 
     brain_extraction_in_files = []
     for n, anat_file in enumerate(copied_anat_filenames):
@@ -657,7 +657,7 @@ def anats_to_template(anat_filenames, head_template_filename, write_dir,
         intermediate_files.append(out_threshold.outputs.out_file)
 
     if brain_extraction_unifize_kwargs is None:
-        brain_extraction_unifize_kwargs = {'cl_frac': .2}
+        brain_extraction_unifize_kwargs = {}
 
     brain_extraction_in_files = []
     for anat_filename in anat_filenames:
@@ -676,7 +676,7 @@ def anats_to_template(anat_filenames, head_template_filename, write_dir,
         brain_mask_files.append(out_rats.outputs.out_file)
 
     if unifize_kwargs is None:
-        unifize_kwargs = {'cl_frac': .2}
+        unifize_kwargs = {}
 
     unbiased_anat_filenames = []
     for anat_filename in anat_filenames:


### PR DESCRIPTION
removed the previous `brain_from_raw` option in `anats_to_common` and replaced it by a double unifization strategy