### PR TITLE
[MRG + 1] expose voxel size in NwarpApply

### DIFF
--- a/sammba/externals/nipype/interfaces/afni/utils.py
+++ b/sammba/externals/nipype/interfaces/afni/utils.py
@@ -1561,10 +1561,9 @@ class NwarpApplyInputSpec(CommandLineInputSpec):
         desc='be extra verbose :)',
         argstr='-verb',
         xor=['quiet'])
-    resolution = traits.Float(
-        argstr='-dxyz %f',
-        desc='resize the master dataset grid spacing to new dx, dy and dz. '
-             '(cubical voxels, in mm)')
+    newgrid = traits.Float(
+        argstr='-newgrid %f',
+        desc='Write the output dataset using isotropic grid spacing in mm.')
 
 
 class NwarpApply(AFNICommandBase):

--- a/sammba/externals/nipype/interfaces/afni/utils.py
+++ b/sammba/externals/nipype/interfaces/afni/utils.py
@@ -1561,9 +1561,8 @@ class NwarpApplyInputSpec(CommandLineInputSpec):
         desc='be extra verbose :)',
         argstr='-verb',
         xor=['quiet'])
-    voxel_size = traits.Tuple(
-        *[traits.Float()] * 3,
-        argstr='-dxyz %f %f %f',
+    resolution = traits.Float(
+        argstr='-dxyz %f',
         desc='resize the master dataset grid spacing to new dx, dy and dz. '
              '(cubical voxels, in mm)')
 

--- a/sammba/externals/nipype/interfaces/afni/utils.py
+++ b/sammba/externals/nipype/interfaces/afni/utils.py
@@ -1561,6 +1561,11 @@ class NwarpApplyInputSpec(CommandLineInputSpec):
         desc='be extra verbose :)',
         argstr='-verb',
         xor=['quiet'])
+    voxel_size = traits.Tuple(
+        *[traits.Float()] * 3,
+        argstr='-dxyz %f %f %f',
+        desc='resize the master dataset grid spacing to new dx, dy and dz. '
+             '(cubical voxels, in mm)')
 
 
 class NwarpApply(AFNICommandBase):

--- a/sammba/registration/func.py
+++ b/sammba/registration/func.py
@@ -517,7 +517,7 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
         Path to the warp transform from anatomical to template space.
 
     voxel_size : 3-tuple of floats, optional
-        Voxel size of the registered functional.
+        Voxel size of the registered functional, in mm.
 
     caching : bool, optional
         Wether or not to use caching.
@@ -545,7 +545,7 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
     warp = "'{0} {1} {2}'".format(anat_to_template_warp_filename,
                                   anat_to_template_oned_filename,
                                   func_to_anat_oned_filename)
-    if voxel_size is not None:
+    if voxel_size is None:
         warp_kwargs = {}
     else:
         warp_kwargs = {'voxel_size': voxel_size}
@@ -602,7 +602,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
         sammba.registration.anats_to_template
 
     voxel_size : 3-tuple of floats, optional
-        Voxel size of the registered functional.
+        Voxel size of the registered functional, in mm.
 
     caching : bool, optional
         Wether or not to use caching.

--- a/sammba/registration/func.py
+++ b/sammba/registration/func.py
@@ -492,6 +492,7 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
                       func_to_anat_oned_filename,
                       anat_to_template_oned_filename,
                       anat_to_template_warp_filename,
+                      voxel_size=None,
                       caching=False, verbose=True):
     """ Applies successive transforms to coregistered functional to put it in
     template space.
@@ -514,6 +515,9 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
 
     anat_to_template_warp_filename : str
         Path to the warp transform from anatomical to template space.
+
+    voxel_size : 3-tuple of floats, optional
+        Voxel size of the registered functional.
 
     caching : bool, optional
         Wether or not to use caching.
@@ -541,10 +545,16 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
     warp = "'{0} {1} {2}'".format(anat_to_template_warp_filename,
                                   anat_to_template_oned_filename,
                                   func_to_anat_oned_filename)
+    if voxel_size is not None:
+        warp_kwargs = {}
+    else:
+        warp_kwargs = {'voxel_size': voxel_size}
+
     _ = warp_apply(in_file=func_coreg_filename,
                    master=template_filename,
                    warp=warp,
-                   out_file=normalized_filename)
+                   out_file=normalized_filename,
+                   **warp_kwargs)
     os.chdir(current_dir)
     return normalized_filename
 

--- a/sammba/registration/func.py
+++ b/sammba/registration/func.py
@@ -492,7 +492,7 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
                       func_to_anat_oned_filename,
                       anat_to_template_oned_filename,
                       anat_to_template_warp_filename,
-                      voxel_size=None,
+                      resolution=None,
                       caching=False, verbose=True):
     """ Applies successive transforms to coregistered functional to put it in
     template space.
@@ -516,8 +516,8 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
     anat_to_template_warp_filename : str
         Path to the warp transform from anatomical to template space.
 
-    voxel_size : 3-tuple of floats, optional
-        Voxel size of the registered functional, in mm.
+    resolution : float, optional
+        Voxel size of the registered functional, in mm (cubical voxels).
 
     caching : bool, optional
         Wether or not to use caching.
@@ -545,10 +545,10 @@ def _func_to_template(func_coreg_filename, template_filename, write_dir,
     warp = "'{0} {1} {2}'".format(anat_to_template_warp_filename,
                                   anat_to_template_oned_filename,
                                   func_to_anat_oned_filename)
-    if voxel_size is None:
+    if resolution is None:
         warp_kwargs = {}
     else:
-        warp_kwargs = {'voxel_size': voxel_size}
+        warp_kwargs = {'resolution': resolution}
 
     _ = warp_apply(in_file=func_coreg_filename,
                    master=template_filename,
@@ -566,7 +566,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
                               prior_rigid_body_registration=False,
                               slice_timing=True,
                               maxlev=2,
-                              voxel_size=None,
+                              resolution=None,
                               caching=False, verbose=True):
     """ Registration of subject's functional and anatomical images to
     a given template.
@@ -601,8 +601,8 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
         Maximal level for the warp when registering anat to template. Passed to
         sammba.registration.anats_to_template
 
-    voxel_size : 3-tuple of floats, optional
-        Voxel size of the registered functional, in mm.
+    resolution : float, optional
+        Voxel size of the registered functional, in mm (cubical voxels).
 
     caching : bool, optional
         Wether or not to use caching.
@@ -693,7 +693,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
             animal_data.output_dir_,
             animal_data.coreg_transform_,
             anat_to_template_oned_filename,
-            anat_to_template_warp_filename, voxel_size=voxel_size,
+            anat_to_template_warp_filename, resolution=resolution,
             caching=caching, verbose=verbose)
 
         setattr(animal_data, "registered_func_", normalized_func_filename)

--- a/sammba/registration/func.py
+++ b/sammba/registration/func.py
@@ -566,6 +566,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
                               prior_rigid_body_registration=False,
                               slice_timing=True,
                               maxlev=2,
+                              voxel_size=None,
                               caching=False, verbose=True):
     """ Registration of subject's functional and anatomical images to
     a given template.
@@ -599,6 +600,9 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
     maxlev : int or None, optional
         Maximal level for the warp when registering anat to template. Passed to
         sammba.registration.anats_to_template
+
+    voxel_size : 3-tuple of floats, optional
+        Voxel size of the registered functional.
 
     caching : bool, optional
         Wether or not to use caching.
@@ -689,7 +693,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
             animal_data.output_dir_,
             animal_data.coreg_transform_,
             anat_to_template_oned_filename,
-            anat_to_template_warp_filename,
+            anat_to_template_warp_filename, voxel_size=voxel_size,
             caching=caching, verbose=verbose)
 
         setattr(animal_data, "registered_func_", normalized_func_filename)

--- a/sammba/registration/func.py
+++ b/sammba/registration/func.py
@@ -566,7 +566,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
                               prior_rigid_body_registration=False,
                               slice_timing=True,
                               maxlev=2,
-                              resolution=None,
+                              func_resolution=None,
                               caching=False, verbose=True):
     """ Registration of subject's functional and anatomical images to
     a given template.
@@ -601,7 +601,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
         Maximal level for the warp when registering anat to template. Passed to
         sammba.registration.anats_to_template
 
-    resolution : float, optional
+    func_resolution : float, optional
         Voxel size of the registered functional, in mm (cubical voxels).
 
     caching : bool, optional
@@ -693,7 +693,7 @@ def fmri_sessions_to_template(sessions, t_r, head_template_filename,
             animal_data.output_dir_,
             animal_data.coreg_transform_,
             anat_to_template_oned_filename,
-            anat_to_template_warp_filename, resolution=resolution,
+            anat_to_template_warp_filename, resolution=func_resolution,
             caching=caching, verbose=verbose)
 
         setattr(animal_data, "registered_func_", normalized_func_filename)


### PR DESCRIPTION
added a new parameter `voxel_size` to allow resampling of the functional in 3dNwarpApply