### PR TITLE
[MRG + 1] add forgotten brain_volume parameter

### DIFF
--- a/examples/02_preprocessing/plot_fmri_coregistration.py
+++ b/examples/02_preprocessing/plot_fmri_coregistration.py
@@ -34,7 +34,7 @@ print(coregistrator)
 # this parameter impacts the brain segmentation
 from sammba.segmentation import brain_extraction_report
 
-print(brain_extraction_report(anat_filename,
+print(brain_extraction_report(anat_filename, brain_volume=400,
                               clipping_fractions=[.1, .2, .9, None]))
 
 ##############################################################################


### PR DESCRIPTION
`brain_volume` parameter was forgotten in the call of `brain_extraction_report` 