### PR TITLE
do not use RATS in examples

### DIFF
--- a/examples/01_template/plot_register.py
+++ b/examples/01_template/plot_register.py
@@ -37,7 +37,8 @@ if not os.path.exists(write_dir):
 # -------------------
 from sammba.registration import anats_to_common
 
-affine_register = anats_to_common(retest.anat, write_dir, 400, caching=True)
+affine_register = anats_to_common(retest.anat, write_dir, 400,
+                                  use_rats_tool=False, caching=True)
 
 ##############################################################################
 # We set caching to True, so that the computations are not restarted.

--- a/examples/02_preprocessing/plot_fmri_coregistration.py
+++ b/examples/02_preprocessing/plot_fmri_coregistration.py
@@ -25,7 +25,7 @@ print(func_filename)
 from sammba.registration import Coregistrator
 
 coregistrator = Coregistrator(output_dir='animal_1366', brain_volume=400,
-                              caching=True)
+                               use_rats_tool=False, caching=True)
 print(coregistrator)
 
 ##############################################################################
@@ -35,7 +35,8 @@ print(coregistrator)
 from sammba.segmentation import brain_extraction_report
 
 print(brain_extraction_report(anat_filename, brain_volume=400,
-                              clipping_fractions=[.1, .2, .9, None]))
+                              clipping_fractions=[.1, .2, .9, None],
+                              use_rats_tool=False))
 
 ##############################################################################
 # Anatomical to functional registration

--- a/examples/03_connectivity/plot_ica.py
+++ b/examples/03_connectivity/plot_ica.py
@@ -33,7 +33,7 @@ dorr_masks.brain.to_filename(template_brain_mask)
 from sammba.registration import TemplateRegistrator
 
 registrator = TemplateRegistrator(brain_volume=400, caching=True,
-                                  template=template,
+                                  template=template, use_rats_tool=False,
                                   template_brain_mask=template_brain_mask)
 
 registered_funcs = []


### PR DESCRIPTION
All examples should be running without RATs, so that doc build can be automatically tested