### PR TITLE
remove mask_clipping_fraction param

### DIFF
--- a/sammba/registration/coregistrator.py
+++ b/sammba/registration/coregistrator.py
@@ -143,13 +143,13 @@ class Coregistrator(BaseRegistrator):
                 compute_brain_mask = compute_histo_brain_mask               
 
             if brain_mask_file is None:
-                if self.mask_clipping_fraction:
+                if self.clipping_fraction:
                     brain_mask_file = compute_brain_mask(
                         to_coregister_file, self.brain_volume,
                         write_dir=self.output_dir,
                         caching=self.caching,
                         terminal_output=self.terminal_output,
-                        cl_frac=self.mask_clipping_fraction,
+                        cl_frac=self.clipping_fraction,
                         verbose=self.verbose)
                 else:
                     brain_mask_file = compute_brain_mask(

--- a/sammba/registration/template_registrator.py
+++ b/sammba/registration/template_registrator.py
@@ -256,13 +256,13 @@ class TemplateRegistrator(BaseRegistrator):
             else:
                 compute_brain_mask = compute_histo_brain_mask               
 
-            if self.mask_clipping_fraction:
+            if self.clipping_fraction:
                 brain_mask_file = compute_brain_mask(
                     to_coregister_file, self.brain_volume,
                     write_dir=self.output_dir,
                     caching=self.caching,
                     terminal_output=self.terminal_output,
-                    cl_frac=self.mask_clipping_fraction,
+                    cl_frac=self.clipping_fraction,
                     verbose=self.verbose)
             else:
                 brain_mask_file = compute_brain_mask(


### PR DESCRIPTION
some code had the removed  `mask_clipping_fraction`. It is replaced here by its new name `clipping_fraction``