### PR TITLE
[MRG] create dorr mask files

### DIFF
--- a/examples/02_preprocessing/plot_fmri_coregistration.py
+++ b/examples/02_preprocessing/plot_fmri_coregistration.py
@@ -1,6 +1,7 @@
 """
 Functional and anatomical coregistration
 ========================================
+
 Standard functional preprocessing and registration of functional image to the
 anatomical.
 """

--- a/examples/03_connectivity/plot_ica.py
+++ b/examples/03_connectivity/plot_ica.py
@@ -28,7 +28,8 @@ from sammba.registration import TemplateRegistrator
 
 registrator = TemplateRegistrator(brain_volume=400, caching=True,
                                   template=dorr.t2, use_rats_tool=False,
-                                  template_brain_mask=dorr_masks.brain)
+                                  template_brain_mask=dorr_masks.brain,
+                                  registration_kind='affine')
 
 registered_funcs = []
 for anat, func in zip(retest.anat, retest.func):

--- a/examples/03_connectivity/plot_ica.py
+++ b/examples/03_connectivity/plot_ica.py
@@ -13,28 +13,22 @@ retest = data_fetchers.fetch_zurich_test_retest(subjects=range(5),
                                                 correct_headers=True)
 
 ##############################################################################
-# Load the template
-# -------------------
+# Load the template and its brain mask
+# ------------------------------------
 dorr = data_fetchers.fetch_atlas_dorr_2008(downsample='100')
-template = dorr.t2
-
-##############################################################################
-# Load the brain mask of the template
-# -----------------------------------
-import os
-
 dorr_masks = data_fetchers.fetch_masks_dorr_2008(downsample='100')
-template_brain_mask = os.path.join('dorr_100_mask.nii.gz')
-dorr_masks.brain.to_filename(template_brain_mask)
+print('Path to template is {} and to the brain mask is {}'.format(dorr.t2,
+      dorr_masks.brain))
 
 ##############################################################################
 # Register to the template
 # ------------------------
+import os
 from sammba.registration import TemplateRegistrator
 
 registrator = TemplateRegistrator(brain_volume=400, caching=True,
-                                  template=template, use_rats_tool=False,
-                                  template_brain_mask=template_brain_mask)
+                                  template=dorr.t2, use_rats_tool=False,
+                                  template_brain_mask=dorr_masks.brain)
 
 registered_funcs = []
 for anat, func in zip(retest.anat, retest.func):

--- a/sammba/__init__.py
+++ b/sammba/__init__.py
@@ -21,6 +21,7 @@ modality_processors     --- Functions for processing raw data of various MRI
                             modalities that are not BOLD fMRI, such as perfusion
 interfaces              --- nipype-like interfaces for small animals tools
 """
+
 import gzip
 
 from .version import _check_module_dependencies, __version__

--- a/sammba/__init__.py
+++ b/sammba/__init__.py
@@ -21,7 +21,10 @@ modality_processors     --- Functions for processing raw data of various MRI
                             modalities that are not BOLD fMRI, such as perfusion
 interfaces              --- nipype-like interfaces for small animals tools
 """
+import sys  
 
+reload(sys)  
+sys.setdefaultencoding('utf8')
 import gzip
 
 from .version import _check_module_dependencies, __version__

--- a/sammba/__init__.py
+++ b/sammba/__init__.py
@@ -21,10 +21,6 @@ modality_processors     --- Functions for processing raw data of various MRI
                             modalities that are not BOLD fMRI, such as perfusion
 interfaces              --- nipype-like interfaces for small animals tools
 """
-import sys  
-
-reload(sys)  
-sys.setdefaultencoding('utf8')
 import gzip
 
 from .version import _check_module_dependencies, __version__

--- a/sammba/data_fetchers/atlas.py
+++ b/sammba/data_fetchers/atlas.py
@@ -206,9 +206,6 @@ def fetch_masks_dorr_2008(image_format='nifti', downsample='30',
 
     corpus_callosum_labels = labels[
         np.in1d(names.astype(str), ['R corpus callosum', 'L corpus callosum'])]
-    print(np.in1d(names.astype(str), ['R corpus callosum', 'L corpus callosum']))
-    print(corpus_callosum_labels)
-    print(np.unique(atlas_data))
     corpus_callosum_mask = np.max(
         [atlas_data == value for value in corpus_callosum_labels], axis=0)
     eroded_corpus_callosum_mask = ndimage.binary_erosion(corpus_callosum_mask,

--- a/sammba/data_fetchers/atlas.py
+++ b/sammba/data_fetchers/atlas.py
@@ -192,48 +192,86 @@ def fetch_masks_dorr_2008(image_format='nifti', downsample='30',
     sammba.data_fetchers.fetch_atlas_dorr_2008: for details regarding
         the DORR 2008 atlas.
     """
-    # Fetching DORR 2008 atlas
-    dorr = fetch_atlas_dorr_2008(
-        image_format=image_format, downsample=downsample, data_dir=data_dir,
-        resume=resume, verbose=verbose)
-    maps, names, labels = dorr['maps'], dorr['names'], dorr['labels']
-    atlas_img = check_niimg(maps)
-    atlas_data = niimg._safe_get_data(atlas_img).astype(int)
+    masks_dir = _get_dataset_dir('dorr_2008', data_dir=data_dir,
+                                 verbose=verbose)
+    if image_format == 'nifti':
+        ext = '.nii.gz'
+    elif image_format == 'minc':
+        ext = '.minc'
+    else:
+        raise ValueError("Images format must be 'nifti' or 'minc', you "
+                         "entered {0}".format(image_format))
 
-    brain_mask = (atlas_data > 0)
-    brain_mask = ndimage.binary_closing(brain_mask, iterations=2)
-    brain_mask_img = image.new_img_like(atlas_img, brain_mask)
+    brain_mask_file = os.path.join(
+        masks_dir,
+        'dorr_2008_brain_mask_{}{}'.format(downsample, ext))
+    gm_mask_file = os.path.join(
+        masks_dir, 'dorr_2008_gm_mask_{}{}'.format(downsample, ext))
+    cc_mask_file = os.path.join(
+        masks_dir, 'dorr_2008_cc_mask_{}{}'.format(downsample, ext))
+    ventricles_mask_file = os.path.join(
+        masks_dir, 'dorr_2008_ventricles_mask_{}{}'.format(downsample, ext))
+    existing_mask_files = [os.path.isfile(f) for f in [brain_mask_file,
+                           gm_mask_file, cc_mask_file, ventricles_mask_file]]
+    if not np.all(existing_mask_files):
+        # Fetching DORR 2008 atlas
+        dorr = fetch_atlas_dorr_2008(
+            image_format=image_format, downsample=downsample,
+            data_dir=data_dir,
+            resume=resume, verbose=verbose)
+        atlas_img = check_niimg(dorr.maps)
+        atlas_data = niimg._safe_get_data(atlas_img).astype(int)
+    
+    if not os.path.isfile(brain_mask_file):
+        brain_mask = (atlas_data > 0)
+        brain_mask = ndimage.binary_closing(brain_mask, iterations=2)
+        brain_mask_img = image.new_img_like(atlas_img, brain_mask)
+        brain_mask_img.to_filename(brain_mask_file)
 
-    corpus_callosum_labels = labels[
-        np.in1d(names.astype(str), ['R corpus callosum', 'L corpus callosum'])]
-    corpus_callosum_mask = np.max(
-        [atlas_data == value for value in corpus_callosum_labels], axis=0)
-    eroded_corpus_callosum_mask = ndimage.binary_erosion(corpus_callosum_mask,
-                                                         iterations=2)
-    corpus_callosum_mask_img = image.new_img_like(atlas_img,
-                                                  eroded_corpus_callosum_mask)
 
-    ventricles_names = ['R lateral ventricle', 'L lateral ventricle',
-                        'third ventricle', 'fourth ventricle']
-    ventricles_labels = labels[np.in1d(names.astype(str), ventricles_names)]
-    ventricles_mask = np.max(
-        [atlas_data == value for value in ventricles_labels], axis=0)
-    eroded_ventricles_mask = ndimage.binary_erosion(ventricles_mask,
-                                                    iterations=2)
-    ventricles_mask_img = image.new_img_like(atlas_img, eroded_ventricles_mask)
+    if not os.path.isfile(cc_mask_file):
+        cc_labels = dorr.labels[
+            np.in1d(dorr.names.astype(str), ['R corpus callosum',
+                                            'L corpus callosum'])]
+        cc_mask = np.max(
+            [atlas_data == value for value in cc_labels], axis=0)
+        eroded_cc_mask = ndimage.binary_erosion(cc_mask, iterations=2)
+        cc_mask_img = image.new_img_like(atlas_img, eroded_cc_mask)
+        cc_mask_img.to_filename(cc_mask_file)
 
-    gm_mask = (atlas_data > 0)
-    gm_mask[ventricles_mask] = 0
-    gm_mask[corpus_callosum_mask] = 0
-    gm_mask = ndimage.binary_closing(gm_mask, iterations=2)
-    gm_mask_img = image.new_img_like(atlas_img, gm_mask)
+    if not os.path.isfile(ventricles_mask_file):
+        ventricles_names = ['R lateral ventricle', 'L lateral ventricle',
+                            'third ventricle', 'fourth ventricle']
+        ventricles_labels = dorr.labels[np.in1d(dorr.names.astype(str),
+                                                ventricles_names)]
+        ventricles_mask = np.max(
+            [atlas_data == value for value in ventricles_labels], axis=0)
+        eroded_ventricles_mask = ndimage.binary_erosion(ventricles_mask,
+                                                        iterations=2)
+        ventricles_mask_img = image.new_img_like(atlas_img,
+                                                 eroded_ventricles_mask)
+        ventricles_mask_img.to_filename(ventricles_mask_file)
 
-    mask_imgs = {'brain': brain_mask_img,
-                 'gm': gm_mask_img,
-                 'cc': corpus_callosum_mask_img,
-                 'ventricles': ventricles_mask_img}
+    if not os.path.isfile(gm_mask_file):
+        gm_mask_img = image.math_img(
+            'np.logical_not(np.logical_or(ventricles_mask_img, cc_mask_img))',
+            ventricles_mask_img=ventricles_mask_img,
+            cc_mask_img=cc_mask_img)
+        gm_mask_img = image.math_img(
+            'np.logical_and(brain_mask_img, gm_mask_img)',
+            brain_mask_img=brain_mask_img,
+            gm_mask_img=gm_mask_img)
+        gm_mask_closed_data = ndimage.binary_closing(gm_mask_img.get_data(),
+                                                     iterations=2)
+        gm_mask_img = image.new_img_like(gm_mask_img, gm_mask_closed_data)
+        gm_mask_img.to_filename(gm_mask_file)
 
-    return Bunch(**mask_imgs)
+    mask_files = {'brain': brain_mask_file,
+                  'gm': gm_mask_file,
+                  'cc': cc_mask_file,
+                  'ventricles': ventricles_mask_file}
+
+    return Bunch(**mask_files)
 
 
 def fetch_atlas_waxholm_rat_2014(data_dir=None, url=None, resume=True,

--- a/sammba/data_fetchers/tests/test_atlas.py
+++ b/sammba/data_fetchers/tests/test_atlas.py
@@ -102,10 +102,10 @@ def test_fetch_masks_dorr_2008():
     dummy_atlas_img.to_filename(dorr_atlas.maps)
 
     dorr_masks = atlas.fetch_masks_dorr_2008(data_dir=tst.tmpdir, verbose=0)
-    assert_true(isinstance(dorr_masks.brain, nibabel.Nifti1Image))
-    assert_true(isinstance(dorr_masks.gm, nibabel.Nifti1Image))
-    assert_true(isinstance(dorr_masks.cc, nibabel.Nifti1Image))
-    assert_true(isinstance(dorr_masks.ventricles, nibabel.Nifti1Image))
+    assert_true(os.path.isfile(dorr_masks.brain))
+    assert_true(os.path.isfile(dorr_masks.gm))
+    assert_true(os.path.isfile(dorr_masks.cc))
+    assert_true(os.path.isfile(dorr_masks.ventricles))
 
 
 @with_setup(setup_mock, teardown_mock)

--- a/sammba/segmentation/brain_mask.py
+++ b/sammba/segmentation/brain_mask.py
@@ -101,7 +101,6 @@ def brain_extraction_report(head_file, brain_volume, write_dir=None,
                                              verbose=verbose,
                                              terminal_output=terminal_output,
                                              **unifize_kwargs)
-        print(brain_mask_file)
         masks_measures.append(_get_mask_measures(brain_mask_file))
 
     target_names = ['fraction {0:0.2f}'.format(cl_frac) if cl_frac is not None


### PR DESCRIPTION
Dorr 2008 masks were nibabel images. This prevented using caching in plot_ica example because the brain mask file was recreated each time. This PR allows to create these files the first time `fetch_dorr_2008_masks` is called.